### PR TITLE
Add link to live version via Heroku site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Live Demo
 
-TBA
+[Heroku site deployed](https://secure-lake-87647.herokuapp.com)
 
 
 ## Getting Started
@@ -46,6 +46,19 @@ Start server with:
 ```
     rails server
 ```
+
+
+To login you can use the following credentials,
+
+Email:
+```
+    user0@email.com ... user69@email.com
+```
+Password:
+```
+    password
+```
+
 
 Open `http://localhost:3000/` in your browser.
 


### PR DESCRIPTION
We are adding a live version hosted in Heroku, for this we merged Develop with Master.
Here is the link to the [live version](https://secure-lake-87647.herokuapp.com) and it is also inside of the README.md file.

Here are the credentials to login:
Email:
```
    user0@email.com ... user69@email.com
```
Password:
```
    password
```